### PR TITLE
removed unnessary custom conditional

### DIFF
--- a/src/containers/SarcophagusCreate/index.tsx
+++ b/src/containers/SarcophagusCreate/index.tsx
@@ -12,7 +12,6 @@ import { useSarcophagiStore } from "../../stores/Sarcophagi";
 import { SarcophagusStore } from "../../stores/Sarcophagi/sarcophagi.interfaces";
 import { useWeb3 } from "../../web3";
 import useFileEncryption from "../../components/SarcophagusCreate/hooks/useFileEncryption";
-import { convertDataToBigNumber } from "../../components/shared/components.utils";
 import { BigNumber, utils } from "ethers";
 import { SarcophagusCreateValues } from "../../components/SarcophagusCreate/sarcophagusCreate.interfaces";
 import { connect } from "../../web3/providers";
@@ -67,11 +66,9 @@ const CreateSarcophagus = () => {
       return;
     }
     try {
-      const { bounty, diggingFee, recipientPublicKey, resurrectionTime, name, custom } = values;
-      let resurrectionTimeBN: BigNumber = custom
-        ? convertDataToBigNumber(resurrectionTime.toString())
-        : BigNumber.from(Number(resurrectionTime) / 1000);
-
+      const { bounty, diggingFee, recipientPublicKey, resurrectionTime, name } = values;
+      let resurrectionTimeBN: BigNumber = BigNumber.from(Number(resurrectionTime) / 1000);
+      
       const diggingFeeBN = utils.parseEther(diggingFee.toString());
       const bountyBN = utils.parseEther(bounty.toString());
       const storageFeeBN = utils.parseEther(storageFee.toString());


### PR DESCRIPTION
## Overview

Removes left over conditional when setting resurrection time when selecting a custom time. causing a 'NAN' value BigNumber error.

## Solution

No longer need the conditional as the value is already set to return the same regardless if custom time is selected or not. 